### PR TITLE
关于lealone stage pool停止时的小bug

### DIFF
--- a/lealone-aose/src/main/java/org/lealone/aose/concurrent/SEPExecutor.java
+++ b/lealone-aose/src/main/java/org/lealone/aose/concurrent/SEPExecutor.java
@@ -181,11 +181,15 @@ public class SEPExecutor extends AbstractLealoneExecutorService {
         }
     }
 
+    // submit一个任务后立即停止，那么会将任务丢掉
+    // for循环submit一批任务后立即停止，仍然会丢一批任务
     @Override
     public synchronized void shutdown() {
         shuttingDown = true;
         pool.executors.remove(this);
-        if (getActiveCount() == 0)
+        boolean empty=tasks.isEmpty();    //  false
+        long active=getActiveCount();     //  zero
+        if (active == 0)                  //  (empty||active==0){ do something }
             shutdown.signalAll();
     }
 


### PR DESCRIPTION
public class JdkPool {

    public static void main(String args[]) {
        ExecutorService service = Executors.newCachedThreadPool();
        SubmitRunner runner = null;
        for (int i = 0; i < 1; i++) {
            runner = new SubmitRunner();
            // 测试结果是，这里有些小问题，就是提交后马上关闭pool会出现丢任务情况
            service.submit(runner);
            //
        }
        //LockSupport.parkNanos(TimeUnit.NANOSECONDS.convert(9, TimeUnit.SECONDS));
        service.shutdown();
        System.out.println("main has shutdown");
    }

}
上述jdk pool不丢任务。
public class CassandraStage {

    public static void main(String args[]) {
        SharedExecutorPool share = new SharedExecutorPool("test-name");
        BaojieExecutorService service = share.newExecutor(555, 555, "test");
        SubmitRunner runner = null;
        for (int i = 0; i < 1; i++) {
            runner = new SubmitRunner();
            // 测试结果是，这里有些小问题，就是提交后马上关闭pool会出现丢任务情况
            service.submit(runner);
            //
        }
        //LockSupport.parkNanos(TimeUnit.NANOSECONDS.convert(9, TimeUnit.SECONDS));
        service.shutdown();
        System.out.println("main has shutdown");
    }

}
上面lealone stage pool会丢任务。
简单runner如下：
public final class SubmitRunner implements Runnable {

    private static final Logger logger = LoggerFactory.getLogger(SubmitRunner.class);

    public SubmitRunner() {

    }

    @Override
    public void run() {
        final String tn=Thread.currentThread().getName();
        logger.debug("park myself");
        LockSupport.parkNanos(TimeUnit.NANOSECONDS.convert(6, TimeUnit.SECONDS));
        logger.debug("unpark myself");
        throw new OutOfMemoryError("i am '"+tn+"' throw an error");
    }

}

这个问题，不清楚对于lealone是否有影响，原因可能是关闭动作缺少中间状态。