### PR TITLE
修复clear后， 重新打开后数据还在的问题

### DIFF
--- a/lealone-aose/src/main/java/org/lealone/storage/aose/btree/BTreeStorage.java
+++ b/lealone-aose/src/main/java/org/lealone/storage/aose/btree/BTreeStorage.java
@@ -315,6 +315,7 @@ public class BTreeStorage {
             return;
         bgc.close();
         chunkManager.close();
+        hasUnsavedChanges = true;
         // FileUtils.deleteRecursive(mapBaseDir, true);
     }
 

--- a/lealone-test/src/test/java/org/lealone/test/aose/BTreeStorageTest.java
+++ b/lealone-test/src/test/java/org/lealone/test/aose/BTreeStorageTest.java
@@ -32,4 +32,22 @@ public class BTreeStorageTest extends AoseTestBase {
 
         map.remove();
     }
+
+    @Test
+    public void testClear() {
+        init();
+
+        openMap();
+        map.clear();
+
+        map.put(10, "a");
+        map.close();
+
+        openMap();
+        map.clear();
+        map.close();
+
+        openMap();
+        assertNull(map.get(10));
+    }
 }


### PR DESCRIPTION
修复了调用clear方法后保存后重新打开，数据还在的问题。 测试用例：`org.lealone.test.aose.BTreeStorageTest#testClear`